### PR TITLE
Fix code issues: namespace comment and Windows DLL export

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ project(synumpy VERSION 1.9.7 LANGUAGES CXX)
 
 include(GNUInstallDirs)
 
+# Automatically export symbols on Windows when building a shared library
+if(WIN32 AND BUILD_SHARED_LIBS)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 option(SYNUMPY_BUILD_EXAMPLE "Build the example executable" ON)
 
 add_library(synumpy synumpy.cpp)

--- a/example.cpp
+++ b/example.cpp
@@ -58,7 +58,7 @@ void printShape(const syNumpy::NpyArray& array) {
         std::cout << array.shape()[i];
     }
     std::cout << ")\n";
-}  // namespace
+}
 
 template <typename T>
 void printValues(const std::vector<T>& values, const char* label) {
@@ -69,7 +69,7 @@ void printValues(const std::vector<T>& values, const char* label) {
     std::cout << "\n";
 }
 
-}
+}  // namespace
 
 int main() {
     try {


### PR DESCRIPTION
## Summary

This PR fixes two code issues found in the codebase:

1. **Fix incorrect namespace comment placement in example.cpp**
   - The `// namespace` comment was placed after the `printShape` function closing brace instead of the actual anonymous namespace closing brace.
   - This has been corrected for better code clarity.

2. **Add Windows shared library symbol export support**
   - When building as a shared library on Windows, enable automatic symbol export via `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`.
   - This prevents linker errors when using the library as a DLL on Windows platforms.

## Test plan

- [x] Code compiles successfully
- [x] Example program runs correctly after changes
- [x] No functional changes to library behavior

## Files changed

- `example.cpp`: Fixed namespace comment placement
- `CMakeLists.txt`: Added Windows DLL export support

🤖 Generated with [Claude Code](https://claude.com/claude-code)